### PR TITLE
Fix Autodesk spelling in skills list

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         </p>
         <h3>Skills</h3>
         <ul>
-          <li>AutoDesk (Revit & AutoCAD)</li>
+          <li>Autodesk (Revit & AutoCAD)</li>
           <li>SQL</li>
           <li>Microsoft Apps</li>
           <li>PowerBI</li>


### PR DESCRIPTION
## Summary
- correct the spelling of `Autodesk` in the skills list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845201ddc008325a77e87d1e02a88be